### PR TITLE
Support uuids as pks on roda actions

### DIFF
--- a/lib/autoforme/frameworks/roda.rb
+++ b/lib/autoforme/frameworks/roda.rb
@@ -21,7 +21,7 @@ module AutoForme
             @env['PATH_INFO']
           end
 
-          path_id = $1 if remaining_path =~ %r{\A\/(\w+)\z}
+          path_id = $1 if remaining_path =~ %r{\A\/([\w-]+)\z}
           set_id(path_id)
         end
 

--- a/spec/basic_spec.rb
+++ b/spec/basic_spec.rb
@@ -142,6 +142,23 @@ describe AutoForme do
     click_button 'Edit'
   end
 
+  it "should support showing models with custom ids" do
+    db_setup(:tracks => proc do
+      column :id, String, :primary_key => true
+      column :name, String
+    end)
+
+    model_setup(:Track => [:tracks])
+    Track.unrestrict_primary_key
+    app_setup(Track)
+
+    Track.create(:id => 'dark-side', :name => 'The Dark Side of the Moon')
+
+    visit("/Track/show/dark-side")
+
+    page.html.must_include 'The Dark Side of the Moon'
+  end
+
   it "should support custom redirects" do
     app_setup(Artist) do
       redirect do |obj, type, req|

--- a/spec/sequel_spec_helper.rb
+++ b/spec/sequel_spec_helper.rb
@@ -7,14 +7,19 @@ module AutoFormeSpec
   def self.db_setup(tables)
     db = Sequel.connect(ENV['DATABASE_URL'] || 'sqlite:/')
     #db.loggers << Logger.new($stdout)
-    tables.each do |table, columns|
+    tables.each do |table, table_spec|
       db.create_table(table) do
-        primary_key :id
-        columns.each do |name, type, opts|
-          column name, TYPE_MAP[type], opts||{}
+        if table_spec.kind_of? Enumerable
+          primary_key :id
+          table_spec.each do |name, type, opts|
+            column name, TYPE_MAP[type], opts||{}
+          end
+        elsif table_spec.respond_to? :call
+          self.instance_eval(&table_spec)
         end
       end
     end
+
     db
   end
 
@@ -22,7 +27,7 @@ module AutoFormeSpec
     models.each do |name, (table, associations)|
       klass = Class.new(Sequel::Model(db[table]))
       Object.const_set(name, klass)
-      klass.class_eval do 
+      klass.class_eval do
         if associations
           associations.each do |type, assoc, opts|
             associate(type, assoc, opts||{})


### PR DESCRIPTION
Fix default action urls for when the primary key of a model includes dashes