### PR TITLE
Respect forme_namespace method on model

### DIFF
--- a/lib/autoforme/models/sequel.rb
+++ b/lib/autoforme/models/sequel.rb
@@ -23,7 +23,7 @@ module AutoForme
 
       # The name of the form param for the given association.
       def form_param_name(assoc)
-        "#{model.send(:underscore, model.name)}[#{association_key(assoc)}]"
+        "#{model.new.forme_namespace}[#{association_key(assoc)}]"
       end
 
       # Set the fields for the given action type to the object based on the request params.
@@ -117,7 +117,7 @@ module AutoForme
       # The namespace for form parameter names for this model, needs to match
       # the ones automatically used by Forme.
       def params_name
-        model.send(:underscore, model.name)
+        model.send(:underscore, model.new.forme_namespace)
       end
 
       # Retrieve underlying model instance with matching primary key

--- a/spec/basic_spec.rb
+++ b/spec/basic_spec.rb
@@ -1120,3 +1120,28 @@ describe AutoForme do
     page.all('td').map{|s| s.text}.must_equal []
   end
 end
+
+describe AutoForme do
+  before(:all) do
+    db_setup(:artists=>[[:name, :string]])
+    Namespace = Module.new
+
+    class Namespace::Artist < Sequel::Model(db[:artists])
+      def forme_namespace
+        "artist"
+      end
+    end
+  end
+  after(:all) do
+    Object.send(:remove_const, :Namespace)
+  end
+
+  it "respects the forme_namespace method on the model" do
+    app_setup(Namespace::Artist)
+    visit("/Namespace::Artist/new")
+    fill_in 'Name', :with=>'TestArtistNew'
+    click_button 'Create'
+    page.html.must_include 'Created Namespace::Artist'
+    page.current_path.must_equal '/Namespace::Artist/new'
+  end
+end


### PR DESCRIPTION
When defining `forme_namespace` on the model, the `params` hash is incorrect when accessed by `autoforme` during the `set_fields` operation, resulting in a `nil` exception.