### PR TITLE
Update path_id regex to match colon characters

### DIFF
--- a/lib/autoforme/frameworks/roda.rb
+++ b/lib/autoforme/frameworks/roda.rb
@@ -23,7 +23,7 @@ module AutoForme
             # :nocov:
           end
 
-          path_id = $1 if remaining_path =~ %r{\A\/([\w-]+)\z}
+          path_id = $1 if remaining_path =~ %r{\A\/([:\w-]+)\z}
           set_id(path_id)
         end
 

--- a/lib/autoforme/frameworks/sinatra.rb
+++ b/lib/autoforme/frameworks/sinatra.rb
@@ -69,7 +69,7 @@ module AutoForme
           suffix = "\\z"
         end
         # :nocov:
-        regexp = %r{#{prefix}/([\w:]+)/(\w+)(?:/([\w-]+))?#{suffix}}
+        regexp = %r{#{prefix}/([\w:]+)/(\w+)(?:/([:\w-]+))?#{suffix}}
         @controller.get regexp, &block
         @controller.post regexp, &block
       end


### PR DESCRIPTION
Matching colon characters is necessary to correctly support namespaced models in URLs.